### PR TITLE
Use "$@" instead of unquoted $@.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To save your type, add this fuction to `~/.bashrc` or `~/.profile`
     ...
     
     function git () {
-        (docker run -ti --rm -v ${HOME}:/root -v $(pwd):/git alpine/git $@)
+        (docker run -ti --rm -v ${HOME}:/root -v $(pwd):/git alpine/git "$@")
     }
     
     ...


### PR DESCRIPTION
Wrapping $@ with double quotes preserves spaces in ARGV. Now commands like `git config user.name "User Name"` and `git commit -m "multiple words"` work properly.