### PR TITLE
Dockerfile does not conform to entrypoint best practice #8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
+sudo: required
+
+services:
+  - docker
+
 script: make

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@ FROM alpine
 
 LABEL maintainer Bill Wang <ozbillwang@gmail.com>
 
-RUN apk --update add git openssh && \
+RUN apk --update add git openssh bash && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
+
+COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
+RUN chmod +x /bin/docker-entrypoint.sh
 
 VOLUME /git
 WORKDIR /git
 
-ENTRYPOINT ["git"]
+ENTRYPOINT ["/bin/docker-entrypoint.sh"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+RELEASE_TYPE ?= patch
+SEMVER_IMAGE ?= alpine/semver
+
+CURRENT_VERSION := $(shell git tag -l -n [0-9]* | sort --version-sort -r | awk 'NR==1{print $$1}' )
+
+ifndef CURRENT_VERSION
+  CURRENT_VERSION := 0.0.0
+endif
+
+NEXT_VERSION := $(shell docker run --rm $(SEMVER_IMAGE) semver -c -i $(RELEASE_TYPE) $(CURRENT_VERSION))
+
+BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+
+.PHONY: all current-version next-version release
+all: release
+
+current-version:
+	@echo $(CURRENT_VERSION)
+
+next-version:
+	@echo $(NEXT_VERSION)
+
+release:
+	if [ "$(BRANCH)" = "master" ];then \
+	  git tag $(NEXT_VERSION) ;\
+	  git push --tags ;\
+	fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -e
+
+# allow to run "sh" or "bash"
+if [ "$1" = 'sh' ] || [ "$1" = 'bash' ]; then
+    exec "$@"
+else
+  # else default to run command with git
+  exec git "$@"
+fi


### PR DESCRIPTION
1.  Add bash for beginning user who should be able to docker run image with bash (or sh)
2. Add `docker-entrypoint.sh` to  conform to entrypoint best practice
3. Sample in  https://github.com/docker-library/official-images#consistency doesn't really work, adjust with simpler solution.