### PR TITLE
Install GNU Less

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 LABEL maintainer Bill Wang <ozbillwang@gmail.com>
 
-RUN apk --update add git openssh && \
+RUN apk --update add git less openssh && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 


### PR DESCRIPTION
Commands like `git log` and `git diff` pipe their output through less, by default. Less, as shipped with busybox, does not support the `-R` and `-r` options, so colors do not work.

This gets messy when used via docker-compose, as the escape chars for colors get printed with the output from these commands, making the output hard to read.

Installing less from the alpine package repo fixes this. I've tested this change locally, and it works like a charm :+1: 

Ref: https://wiki.alpinelinux.org/wiki/Alpine_Linux:FAQ#How_to_enable.2Ffix_colors_for_git.3F