### PR TITLE
removed the container to run as root and added a user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM alpine
 
-LABEL maintainer Bill Wang <ozbillwang@gmail.com>
+LABEL maintainer="Bill Wang <ozbillwang@gmail.com>"
 
 RUN apk --update add git less openssh && \
     rm -rf /var/lib/apt/lists/* && \
-    rm /var/cache/apk/*
+    rm /var/cache/apk/* && \
+    adduser -D -s /bin/sh -g "git user" git-user
 
 VOLUME /git
 WORKDIR /git
+
+USER git-user
 
 ENTRYPOINT ["git"]
 CMD ["--help"]

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ if [[ "$TRAVIS_BRANCH" == "master" ]]; then
   docker push ${image}:latest
 
   # add another tag with git version, with this way, we can check this git image health
-  VERSION=($( docker run -ti --rm alpine/git version|awk '{print $NF}'))
+  VERSION=($(docker run -i --rm alpine/git version|awk '{print $NF}'))
   echo ${VERSION}
   docker tag ${image}:${NEXT_TAG} ${image}:v${VERSION}
   docker push ${image}:v${VERSION}


### PR DESCRIPTION
also, updated the LABEL field with the recommend key-value pair syntax

This also helps to run the image on k8s clusters which do not allow to run containers with root user. Also, recommended by [docker](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user)

Signed-off-by: Vikas Kumar <vikas@reachvikas.com>