### PR TITLE
Adding arm64 architecture support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 jobs:
   allow_failures:
-  - if: arch in (s390x, ppc64le) 
+  - if: arch in (s390x, ppc64le, arm64)
   include:
     - stage: build amd64
       workspaces:
@@ -27,6 +27,12 @@ jobs:
         use: ws1
       script:
       - bash ./build.sh 
+    - stage: build arm64
+      arch: arm64
+      workspaces:
+        use: ws1
+      script:
+      - bash ./build.sh
     - stage: make multi-arch images
       workspaces:
         use: ws1

--- a/multi-arch-image.sh
+++ b/multi-arch-image.sh
@@ -10,7 +10,7 @@ set -e
 function get_arch_images(){
     image=$1; shift || fatal "usage error"
     tag=$1; shift || fatal "usage error"
-    archs="amd64 s390x ppc64le"
+    archs="amd64 s390x ppc64le arm64"
     for arch in $archs; do
         if [[ "$(docker pull ${image}:${tag}-${arch} >/dev/null 2>&1 ; echo $?)" == 0 ]]; then
         	echo "${image}:${tag}-${arch} "


### PR DESCRIPTION
I would love to have linux/arm64 support of the `alpine/git` image to run it on my 64bit Raspberry Pi 4.
It looks like Travis has arm64 support, so I hope it's easy like this change to add arm64 support to the multi-arch image.
