### PR TITLE
Install Git LFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine
 
 RUN apk fix
-RUN apk --update add git less openssh && \
+RUN apk --update add git git-lfs less openssh && \
+    git lfs install && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 


### PR DESCRIPTION
Git Large File Storage (LFS) is a commonly used plugin which avoids adding very large blobs to Git: https://git-lfs.github.com/

This patch adds the git-lfs package and then initializes Git LFS so it will run properly.