### PR TITLE
README.md: Update Travis CI build URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This feature was added on 23th May 2021.
 
 https://github.com/alpine-docker/git
 
-### travis CI build logs
+### Travis CI build logs
 
-https://travis-ci.com/alpine-docker/git
+https://app.travis-ci.com/github/alpine-docker/git
 
 ### Docker image tags
 


### PR DESCRIPTION
Travis has changed their URL structure. This patch provides the correct link.