### PR TITLE
added gpg to image to support git verify-commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk fix && \
-    apk --no-cache --update add git git-lfs less openssh && \
+    apk --no-cache --update add git git-lfs gpg less openssh && \
     git lfs install
 
 VOLUME /git


### PR DESCRIPTION
hello there 👋 

i tried to use this image in a CI way to check if the commit in question is verified. sadly this image does not contain a `gpg` package, which results in the following error:

```
git verify-commit $SHA
error: cannot run gpg: No such file or directory
```

adding `gpg` into the image makes it possible to use this git command:
```
git verify-commit $SHA
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: Signature made Mon Aug 22 10:21:24 2022 UTC
gpg:                using RSA key $KEY
```

 As this is now part of the standard git usage, i think `gpg` should be added to this image.

feel free to close this PR if you disagree with that 😃 