### PR TITLE
Always add a user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine
 
 RUN apk fix && \
     apk --no-cache --update add git git-lfs gpg less openssh patch && \
-    git lfs install
+    git lfs install && \
+    adduser -D -s /bin/sh -g git-user git-user
 
 VOLUME /git
 WORKDIR /git


### PR DESCRIPTION
This PR always adds a user `git-user`. The `adduser` command is inspired on your stale `non-root` branch.

My reason to always add a user, but not use, is to have the possibility to use it as a devcontainer in vscode.

I have a couple of repositories that I use to maintain my notes on various subjects. In vscode when you want to use a devcontainer as non-root, vscode requires to have that there is a user available in the container. There is no easy way to add it afterwards unless you create a new `Dockerfile` and use that to build your own base-devcontainer. So by always adding the user, I can use this container in vscode really easily.

I tried to pull your `alpine/git:user` from docker hub, but that is too old and doesn't work with vscode.

As far as I can see, adding this doesn't bother the current users who use the container as-is.